### PR TITLE
JS lines back in Controller Aplication

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -8,3 +8,5 @@ window.Stimulus   = application
 
 export { application }
 
+import ToggleSignupFieldsController from "./toggle_signup_fields_controller.js"
+Stimulus.register("toggle-signup-fields", ToggleSignupFieldsController)


### PR DESCRIPTION
Getting back two JS Controller Aplication lines (deleted during Heroku Bug fix with Pato)